### PR TITLE
Let cargo decide when to upgrade

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,60 +14,14 @@ fn main() {
 }
 
 fn run() -> Result<(), String> {
-    use std::collections::HashMap;
-
     let installed_crates = installed_crates()?;
-    let mut required_crates = HashMap::new();
-    for c in installed_crates.values() {
-        if required_crates.contains_key(&c.name) {
-            println!("Ignoring duplicate installed crate: {:?}", c);
-            continue;
-        }
 
-        let mut required_crate = c.clone();
-        // require latest version with no constraints
-        required_crate.version = "*".into();
-        if required_crates
-            .insert(c.name.clone(), required_crate)
-            .is_some()
-        {
-            unreachable!("duplicate key");
-        }
-    }
-
-    let latest_versions = get_latest_versions(&required_crates)?;
-
-    let mut updates = Vec::new();
-    for c in installed_crates.values() {
-        let latest_version = latest_versions
-            .get(&c.name)
-            .ok_or(format!("Error: No latest version found for {}", c.name))?;
-        if &c.version != latest_version {
-            updates.push((c, latest_version));
-        } else {
-            println!("Up to date: {} {}", c.name, c.version);
-        }
-    }
-    updates.sort_unstable_by_key(|(c, _)| &c.name);
-
-    if updates.len() > 1 {
-        println!("\nThe following updates will be performed:");
-        for (_crate, latest_version) in &updates {
-            println!("    {} from {} to {}", _crate.name, _crate.version, latest_version);
-        }
-    }
-
-    for (_crate, latest_version) in &updates {
-        println!(
-            "\nUpdating {} from {} to {}",
-            _crate.name, _crate.version, latest_version
-        );
-        if !install_update(&_crate.name, latest_version)?.success() {
+    for c in installed_crates.keys() {
+        println!("Updating `{c}`");
+        if !install_update(c)?.success() {
             return Err("Error: `cargo install` failed".into());
         }
     }
-
-    println!("\nAll packages up to date.");
 
     Ok(())
 }


### PR DESCRIPTION
The `cargo install` command was not able to update installed binaries 4 years ago. So we needed to use some hacks to detect available updates manually and then use `--force` to reinstall the newer versions. Apparently this code has some issues with ordering versions numbers, as reported in #1.

While we could use the [`semver`](https://docs.rs/semver/1.0.17/semver/) crate to get the correct order, we can also use the "install-update" feature of cargo itself, which was [stabilized in Rust 1.41](https://github.com/rust-lang/cargo/pull/7560). Using this feature, this PR is able to vastly simlify the crate. We now just parse the `cargo install --list` output to detect the installed crates and then pass each of them to `cargo install`. The `cargo install` command will then figure out whether do upgrade or not itself.

Fixes #1.